### PR TITLE
enable continuous integration with Travis

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,3 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^\.travis\.yml$

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .Rproj.user
 .Rhistory
-.RData
+*.RData
 funtooNorm.Rproj
 .Rbuildignore
-.gitignore
+# files created during vignette building
+*.pdf
+vignettes/*
+!vignettes/funtooNorm.Rnw

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: r
+sudo: required
+
+bioc_packages:
+  - BiocStyle
+  - illuminaio
+  - minfi
+
+r_binary_packages:
+  - knitr
+  - pls
+
+apt_packages:
+  - latex-xcolor
+
+notifications:
+  email:
+    - maxime.turgeon@mail.mcgill.ca

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ bioc_packages:
   - BiocStyle
   - illuminaio
   - minfi
+  - minfiData
 
 r_binary_packages:
   - knitr

--- a/R/funtoonorm.R
+++ b/R/funtoonorm.R
@@ -74,7 +74,7 @@ funtoonorm <- function(sigA, sigB, Annot=NULL,
   
   
   if (is.null(Annot))  {
-    cat("Since Annot is NULL using default annotation.", '\n')
+    message("Since Annot is NULL using default annotation.", '\n')
     data('Annot', package='funtooNorm', envir = environment())
   }
   
@@ -86,7 +86,7 @@ funtoonorm <- function(sigA, sigB, Annot=NULL,
       cp.types <- rownames(controlgrn)
     }
     if (!(any(names(cp.types.tab)=="NEGATIVE")))  {
-      cat("Since cp.types is NULL and rownames of control probe matrices do not contain,", "\n", 
+      message("Since cp.types is NULL and rownames of control probe matrices do not contain,", "\n", 
           "this information, analysis will use default cp.types.", '\n')
       data('cp.types', package='funtooNorm', envir = environment())
       cp.types.tab <- table(cp.types)
@@ -94,7 +94,7 @@ funtoonorm <- function(sigA, sigB, Annot=NULL,
   }
   
   #checking sanity of the data
-  cat("Checking sanity of the data...", '\n')
+  message("Checking sanity of the data...", '\n')
   if (NotNumeric(sigA)){stop("There are non-numeric values in the matrix", '\n')}
   if (NotNumeric(sigB)){stop("There are non-numeric values in the matrix", '\n')}
   if (NotNumeric(controlred)){stop("There are non-numeric values in the matrix", '\n')}
@@ -125,7 +125,7 @@ funtoonorm <- function(sigA, sigB, Annot=NULL,
     stop("apparent inconsistency w.r.t. log transformation of sigA/B data and control data \n")
   }
   if (max(sigA, na.rm=TRUE)>25) {
-    cat("Assuming data have not been previously log transformed, and applying a log transformation, \n")
+    message("Assuming data have not been previously log transformed, and applying a log transformation, \n")
     logged.data <- FALSE
   }
   
@@ -135,7 +135,7 @@ funtoonorm <- function(sigA, sigB, Annot=NULL,
   cpg<-intersect(rownames(sigA), rownames(Annot))
   Annot=Annot[cpg,]
   
-  cat("Data is ok.", '\n')
+  message("Data is ok.", '\n')
   
   if (!logged.data) {        # log transformation if data are not already logged at input
     sigA <- log2(1 + sigA)
@@ -194,8 +194,10 @@ funtoonorm <- function(sigA, sigB, Annot=NULL,
   # construct control probe summaries, averages by type of control probe
   # then specifically create columns by cell type
   for (k in (1:length(cp.types.tab))) {
-    temp1 <- apply(controlred[cp.types==names(cp.types.tab[k]), , drop=FALSE],2,mean)
-    temp2 <- apply(controlgrn[cp.types==names(cp.types.tab[k]), , drop=FALSE],2,mean)
+    # temp1 <- apply(controlred[cp.types==names(cp.types.tab[k]), , drop=FALSE],2,mean)
+    # temp2 <- apply(controlgrn[cp.types==names(cp.types.tab[k]), , drop=FALSE],2,mean)
+    temp1 <- colMeans(controlred[cp.types==names(cp.types.tab[k]), , drop=FALSE])
+    temp2 <- colMeans(controlgrn[cp.types==names(cp.types.tab[k]), , drop=FALSE])
     if (k==1) {
       mat.by.ct <- cbind(temp1,temp2)  }
     if (k>1) {  mat.by.ct <- cbind(mat.by.ct, cbind(temp1,temp2))  }
@@ -231,7 +233,7 @@ funtoonorm <- function(sigA, sigB, Annot=NULL,
       stop('There may be a problem with the SVD decomposition of the control matrix: number of components needed is either>20 or missing', "\n")
     }
     
-    cat('\n', 'Starting validation with ', numcomp , ' components...',  '\n')
+    message('\n', 'Starting validation with ', numcomp , ' components...',  '\n')
     
     cores=1 #probably does not make sense to use parallelisation
     pls.options(parallel = cores)
@@ -287,19 +289,32 @@ funtoonorm <- function(sigA, sigB, Annot=NULL,
     rmse2.Bgrn <- rmse1.Ared; rmse2.BII <- rmse1.Ared
     
     for (i.n in (1:numcomp)) {
-      rmse1.Ared[i.n,] <- sqrt(apply((mat1P.Ared[,,i.n]-quantilesA.red)^2, 2, sum))
-      rmse1.Agrn[i.n,] <- sqrt(apply((mat1P.Agrn[,,i.n]-quantilesA.grn)^2, 2, sum))
-      rmse1.AII[i.n,] <- sqrt(apply((mat1P.AII[,,i.n]-quantilesA.II)^2, 2, sum))
-      rmse1.Bred[i.n,] <- sqrt(apply((mat1P.Bred[,,i.n]-quantilesB.red)^2, 2, sum))
-      rmse1.Bgrn[i.n,] <- sqrt(apply((mat1P.Bgrn[,,i.n]-quantilesB.grn)^2, 2, sum))
-      rmse1.BII[i.n,] <- sqrt(apply((mat1P.BII[,,i.n]-quantilesB.II)^2, 2, sum))
+      # rmse1.Ared[i.n,] <- sqrt(apply((mat1P.Ared[,,i.n]-quantilesA.red)^2, 2, sum))
+      # rmse1.Agrn[i.n,] <- sqrt(apply((mat1P.Agrn[,,i.n]-quantilesA.grn)^2, 2, sum))
+      # rmse1.AII[i.n,] <- sqrt(apply((mat1P.AII[,,i.n]-quantilesA.II)^2, 2, sum))
+      # rmse1.Bred[i.n,] <- sqrt(apply((mat1P.Bred[,,i.n]-quantilesB.red)^2, 2, sum))
+      # rmse1.Bgrn[i.n,] <- sqrt(apply((mat1P.Bgrn[,,i.n]-quantilesB.grn)^2, 2, sum))
+      # rmse1.BII[i.n,] <- sqrt(apply((mat1P.BII[,,i.n]-quantilesB.II)^2, 2, sum))
+      # 
+      # rmse2.Ared[i.n,] <- sqrt(apply((mat2P.Ared[,,i.n]-quantilesA.red)^2, 2, sum))
+      # rmse2.Agrn[i.n,] <- sqrt(apply((mat2P.Agrn[,,i.n]-quantilesA.grn)^2, 2, sum))
+      # rmse2.AII[i.n,] <- sqrt(apply((mat2P.AII[,,i.n]-quantilesA.II)^2, 2, sum))
+      # rmse2.Bred[i.n,] <- sqrt(apply((mat2P.Bred[,,i.n]-quantilesB.red)^2, 2, sum))
+      # rmse2.Bgrn[i.n,] <- sqrt(apply((mat2P.Bgrn[,,i.n]-quantilesB.grn)^2, 2, sum))
+      # rmse2.BII[i.n,] <- sqrt(apply((mat2P.BII[,,i.n]-quantilesB.II)^2, 2, sum))
+      rmse1.Ared[i.n,] <- sqrt(colSums((mat1P.Ared[,,i.n]-quantilesA.red)^2))
+      rmse1.Agrn[i.n,] <- sqrt(colSums((mat1P.Agrn[,,i.n]-quantilesA.grn)^2))
+      rmse1.AII[i.n,] <- sqrt(colSums((mat1P.AII[,,i.n]-quantilesA.II)^2))
+      rmse1.Bred[i.n,] <- sqrt(colSums((mat1P.Bred[,,i.n]-quantilesB.red)^2))
+      rmse1.Bgrn[i.n,] <- sqrt(colSums((mat1P.Bgrn[,,i.n]-quantilesB.grn)^2))
+      rmse1.BII[i.n,] <- sqrt(colSums((mat1P.BII[,,i.n]-quantilesB.II)^2))
       
-      rmse2.Ared[i.n,] <- sqrt(apply((mat2P.Ared[,,i.n]-quantilesA.red)^2, 2, sum))
-      rmse2.Agrn[i.n,] <- sqrt(apply((mat2P.Agrn[,,i.n]-quantilesA.grn)^2, 2, sum))
-      rmse2.AII[i.n,] <- sqrt(apply((mat2P.AII[,,i.n]-quantilesA.II)^2, 2, sum))
-      rmse2.Bred[i.n,] <- sqrt(apply((mat2P.Bred[,,i.n]-quantilesB.red)^2, 2, sum))
-      rmse2.Bgrn[i.n,] <- sqrt(apply((mat2P.Bgrn[,,i.n]-quantilesB.grn)^2, 2, sum))
-      rmse2.BII[i.n,] <- sqrt(apply((mat2P.BII[,,i.n]-quantilesB.II)^2, 2, sum))
+      rmse2.Ared[i.n,] <- sqrt(colSums((mat2P.Ared[,,i.n]-quantilesA.red)^2))
+      rmse2.Agrn[i.n,] <- sqrt(colSums((mat2P.Agrn[,,i.n]-quantilesA.grn)^2))
+      rmse2.AII[i.n,] <- sqrt(colSums((mat2P.AII[,,i.n]-quantilesA.II)^2, 2))
+      rmse2.Bred[i.n,] <- sqrt(colSums((mat2P.Bred[,,i.n]-quantilesB.red)^2))
+      rmse2.Bgrn[i.n,] <- sqrt(colSums((mat2P.Bgrn[,,i.n]-quantilesB.grn)^2))
+      rmse2.BII[i.n,] <- sqrt(colSums((mat2P.BII[,,i.n]-quantilesB.II)^2))
     }
     
     pdf(file = 'validationcurves.PCR.pdf', height=7, width=7)
@@ -424,7 +439,7 @@ funtoonorm <- function(sigA, sigB, Annot=NULL,
     
     #dev.off()
     
-    cat('Done. Check your working directory for the file "validationcurves.PCR.pdf" and validationcurves.PLS.pdf"', '\n')
+    message('Done. Check your working directory for the file "validationcurves.PCR.pdf" and validationcurves.PLS.pdf"', '\n')
     return()
   }    # end if validate
   #########################

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # funtooNorm 
 
 
-The R package <b>funtooNorm</b>  provides a function for normalization of Illumina Infinium Human Methylation 450
+The R package ```funtooNorm```  provides a function for normalization of Illumina Infinium Human Methylation 450
 BeadChip (Illumina 450K) data when there are samples from multiple tissues or cell types.
 
 ## Installation options
-Download current build <a href="https://github.com/GreenwoodLab/funtooNorm/releases" ><b>here</b></a> and install it with
-<pre>
-$R CMD INSTALL funtooNorm_N.NN.N.tar.gz
-</pre>
+Download the current build <a href="https://github.com/GreenwoodLab/funtooNorm/releases" ><b>here</b></a> and install it with
+``` shell
+$ R CMD INSTALL funtooNorm_N.NN.N.tar.gz
+```
 
 Or, if you want to build from source, you can also install from GitHub using the [devtools](http://cran.r-project.org/web/packages/devtools/index.html) package in `R`: 
 ```r
@@ -16,25 +16,22 @@ library(devtools)
 install_github('GreenwoodLab/funtooNorm', local=TRUE, build_vignettes = TRUE)
 ```
 
-If you have difficulties with <i>install_github</i> function you can download and install source with R CMD build and install commands:
-<pre>
-$git clone https://github.com/GreenwoodLab/funtooNorm.git
-$R CMD build ./funtooNorm
-$R CMD INSTALL funtooNorm_N.NN.N.tar.gz
+If you have difficulties with the function ```install_github``` you can download and install from source using the commands ```R CMD build``` and ```install```:
+``` shell
+$ git clone https://github.com/GreenwoodLab/funtooNorm.git
+$ R CMD build ./funtooNorm
+$ R CMD INSTALL funtooNorm_N.NN.N.tar.gz
 =======
 install_github('greenwoodLab/funtooNorm')
-</pre>
-
-
+```
 
 ## Usage
 
-There are two functions in the package, <i>funtoonorm</i> and <i>agreement</i>. 
+There are two functions in the package, ```funtoonorm``` and ```agreement```. 
 
-The output of <i>funtoonorm</i> function is two matrices: both a normalized methylation data set of beta values and also raw, non-normalized beta values. As an input, the user needs to provide signal A and signal B matrices of data extracted from Illumina IDAT files, as well as control probes signals. The function also requires a list of cell types or tissues. Besides its main purpose of normalization, <i>funtoonorm</i> can be run in a validation mode and its graphical output is used to choose optimal parameters for normalization. 
+The output of ```funtoonorm``` is two matrices: both a normalized methylation data set of beta values and also raw, non-normalized beta values. As an input, the user needs to provide signal A and signal B matrices of data extracted from Illumina IDAT files, as well as control probes signals. The function also requires a list of cell types or tissues. Besides its main purpose of normalization, ```funtoonorm``` can be run in a validation mode and its graphical output is used to choose optimal parameters for normalization. 
 
+The function ```agreement``` accesses the performance of normalization measuring intra-replicate differences before and after normalization. It takes the output of ```funtoonorm``` as an input.
 
-Function <i>agreement</i> accesses the performance of normalization measuring intra-replicate differences before and after normalization. It takes output of <i>funtoonorm</i> as an input.
-
-For more details, see the vignette provided in package or download .pdf file from <a href="https://github.com/GreenwoodLab/funtooNorm/releases"><b>here</b></a>.
+For more details, see the vignette provided with the package or download the pdf file from <a href="https://github.com/GreenwoodLab/funtooNorm/releases"><b>here</b></a>.
 


### PR DESCRIPTION
I made a few changes:
- I enabled continuous integration via Travis-CI. This means that every time commits are pushed or pull-requests are merged, `R CMD check` is run. And if there is any problems (e.g. examples in the doc don't run anymore or building the vignette throws an error), an email is sent and we can figure out right away if anything went wrong; the current email address is mine, but this can easily be changed by modifying the file `.travis.yml`. This is the main change I wanted to implement.
- While doing this, I also made some minor changes to the function `funtoonorm`: I changed all calls to `cat` by calls to `message`. This is considered good practice by the R community, since messages can be turned off, but not what is printed by `cat`. 
- I also changed the calls of the form `apply(mat, 2, mean)` and `apply(mat, 2, sum)` by their vectorized forms, namely `colMeans(mat)` and `colSums(mat)`. It led to a slight performance improvement, but nothing major. I left the original calls in the code (I commented them out).

Feel free to override some of these changes if you disagree.
