### PR TITLE
fix example in agreement doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # funtooNorm 
-
+[![Build Status](https://travis-ci.org/GreenwoodLab/funtooNorm.svg?branch=master)](https://travis-ci.org/GreenwoodLab/funtooNorm)
 
 The R package ```funtooNorm```  provides a function for normalization of Illumina Infinium Human Methylation 450
 BeadChip (Illumina 450K) data when there are samples from multiple tissues or cell types.

--- a/man/agreement.Rd
+++ b/man/agreement.Rd
@@ -41,7 +41,7 @@
      funtoonormout <- funtoonorm(sigA=sigAsample, sigB=sigBsample, Annot=Annot,
                       controlred=matred, controlgrn=matgrn,
                       cp.types=NULL, cell_type = cell_type,
-                      logged.data=FALSE, save.quant=TRUE, ncmp=ncmp, apply.fits=TRUE,
+                      logged2.data=FALSE, save.quant=TRUE, ncmp=ncmp, apply.fits=TRUE,
                       validate=FALSE)
  
      #To calculate measures of agreement before and  after normalization


### PR DESCRIPTION
There is also an example in the man page for the function `agreement`, and the argument `logged.data` needed to be changed to `logged2.data`. This discrepancy is what triggered the build error.

I've also added the travis badge to the README, so we'll see right away if new commits create build errors.
