### PR TITLE
Fix Travis build status link in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # funtooNorm 
-[![Build Status]
-(https://travis-ci.org/GreenwoodLab/funtooNorm.svg?branch=master)]
-(https://travis-ci.org/GreenwoodLab/funtooNorm)
+[![Build Status](https://travis-ci.org/GreenwoodLab/funtooNorm.svg?branch=master)](https://travis-ci.org/GreenwoodLab/funtooNorm)
 
 The R package ```funtooNorm```  provides a function for normalization of 
 Illumina Infinium Human Methylation 450 BeadChip (Illumina 450K) data 


### PR DESCRIPTION
Both the link and the image for the travis build status in the README are currently broken due to newlines.

This removes the lines to fix the display on GitHub.